### PR TITLE
Drop final 'X, not Y' flourish ('lobbying fails')

### DIFF
--- a/manufacturing/industrial-base-math.md
+++ b/manufacturing/industrial-base-math.md
@@ -786,7 +786,7 @@ Because each term is dimensionless and bounded in `[0, 1]`, the score is interpr
 
 Qualitatively, the top tier for India is likely to include active pharma ingredients, mature-node semiconductor inputs, lithium-cell precursors, rare-earth permanent magnets, and selected chemical intermediates. Textiles and food processing may be employment-intensive, but they are already domestically thick; they need a different policy mix.
 
-The sector list should be recomputed and published. Graduation should be automatic. If import vulnerability falls or domestic supplier thickness rises, the sector exits the top tier. The concession ends when capability is built, not when lobbying fails.
+The sector list should be recomputed and published. Graduation should be automatic. If import vulnerability falls or domestic supplier thickness rises, the sector exits the top tier.
 
 The sector score and geography score should be combined only after both are normalized. A conservative rule is a two-stage screen:
 


### PR DESCRIPTION
L789 'The concession ends when capability is built, not when lobbying fails.' was the same in-sentence rhetorical pattern cleaned out elsewhere. The two preceding sentences in that paragraph already state the graduation rule (automatic + triggered by falling import vulnerability or rising supplier thickness), so the trailing sentence was redundant in addition to slop-shaped. Removed entirely.